### PR TITLE
Fix build error for Leap

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -15,8 +15,9 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 #
 
+#
 # This file is maintained at the following location:
-# https://github.com/cockpit-project/cockpit/blob/master/tools/cockpit.spec
+# https://github.com/cockpit-project/cockpit/blob/main/tools/cockpit.spec
 #
 # If you are editing this file in another location, changes will likely
 # be clobbered the next time an automated release is done.
@@ -37,138 +38,179 @@
 %define rhel %{centos}
 %endif
 
-%if "%{!?__python3:1}"
-%define __python3 /usr/bin/python3
-%endif
-
-# for testing this already gets set in fedora.install, as we want the target
-# VERSION_ID, not the mock chroot's one
-%if "%{!?os_version_id:1}"
-%define os_version_id %(. /etc/os-release; echo $VERSION_ID)
-%endif
-
 %define _hardened_build 1
-
-# define to build the dashboard
-%define build_dashboard 1
-
-# build basic packages like cockpit-bridge
-%define build_basic 1
-# build optional extensions like cockpit-docker
-%define build_optional 1
 
 %define __lib lib
 
-%if 0%{?rhel}
-%define vdo_on_demand 1
-%endif
-
-%if 0%{?suse_version}
+%if 0%{?suse_version} <= 1500
 %define pamdir /%{_lib}/security
 %else
+%if %{defined _pamdir}
+%define pamdir %{_pamdir}
+%else
 %define pamdir %{_libdir}/security
+%endif
 %endif
 
 Name:           cockpit
 Summary:        Web Console for Linux servers
+License:        LGPL-2.1-or-later
 
-License:        LGPLv2+
 URL:            https://cockpit-project.org/
 
-Version:        0
-%if %{defined wip}
-Release:        1.%{wip}%{?dist}
-Source0:        cockpit-%{version}.tar.gz
+Version:        250
+Release:        0
+Source0:        cockpit-%{version}.tar
+Source1:        cockpit.pam
+Source2:        cockpit-rpmlintrc
+Source99:       README.packaging
+Source98:       package-lock.json
+Source97:       node_modules.spec.inc
+%include        %{_sourcedir}/node_modules.spec.inc
+Patch0:         cockpit-redhatfont.diff
+Patch1:         0001-selinux-allow-login-to-read-motd-file.patch
+
+# in RHEL 8 the source package is duplicated: cockpit (building basic packages like cockpit-{bridge,system})
+# and cockpit-appstream (building optional packages like cockpit-{pcp})
+# This split does not apply to EPEL/COPR.
+# In Fedora ELN/RHEL 9+ there is just one source package, which ships rpms in both BaseOS and AppStream
+%if 0%{?rhel} == 8 && 0%{?epel} == 0
+
+%if "%{name}" == "cockpit"
+%define build_basic 1
+%define build_optional 0
 %else
-Release:        1%{?dist}
-Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
+%define build_basic 0
+%define build_optional 1
 %endif
 
-BuildRequires: gcc
-BuildRequires: pkgconfig(gio-unix-2.0)
-BuildRequires: pkgconfig(json-glib-1.0)
-BuildRequires: pkgconfig(polkit-agent-1) >= 0.105
-BuildRequires: pam-devel
-
-BuildRequires: autoconf automake
-BuildRequires: make
-BuildRequires: /usr/bin/python3
-BuildRequires: gettext >= 0.19.7
-%if %{defined build_dashboard}
-BuildRequires: libssh-devel >= 0.8.5
+%else
+%define build_basic 1
+%define build_optional 1
 %endif
-BuildRequires: openssl-devel
-BuildRequires: gnutls-devel >= 3.4.3
-BuildRequires: zlib-devel
-BuildRequires: krb5-devel >= 1.11
-BuildRequires: libxslt-devel
-BuildRequires: glib-networking
-BuildRequires: sed
 
-BuildRequires: glib2-devel >= 2.50.0
+# Ship custom SELinux policy only in Fedora and RHEL-9 onward
+%if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version} > 1500
+%define selinuxtype targeted
+%define with_selinux 1
+%define selinux_policy_version %(rpm --quiet -q selinux-policy && rpm -q --queryformat "%{V}-%{R}" selinux-policy || echo 1)
+%endif
+
+BuildRequires:  gcc
+BuildRequires:  pam-devel
+BuildRequires:  pkgconfig(gio-unix-2.0)
+BuildRequires:  pkgconfig(json-glib-1.0)
+BuildRequires:  pkgconfig(polkit-agent-1) >= 0.105
+
+BuildRequires:  /usr/bin/python3
+BuildRequires:  autoconf
+BuildRequires:  automake
+BuildRequires:  gettext >= 0.19.7
+BuildRequires:  make
+%if 0%{?build_basic}
+BuildRequires:  libssh-devel >= 0.8.5
+%endif
+BuildRequires:  glib-networking
+BuildRequires:  gnutls-devel >= 3.4.3
+BuildRequires:  libxslt-devel
+BuildRequires:  openssl-devel
+BuildRequires:  sed
+BuildRequires:  zlib-devel
+BuildRequires:  pkgconfig(krb5) >= 1.11
+
+BuildRequires:  glib2-devel >= 2.50.0
 # this is for runtimedir in the tls proxy ace21c8879
-BuildRequires: systemd-devel >= 235
+BuildRequires:  pkgconfig(libsystemd) >= 235
 %if 0%{?suse_version}
-BuildRequires: distribution-release
-BuildRequires: libpcp-devel
-BuildRequires: pcp-devel
-BuildRequires: libpcp3
-BuildRequires: libpcp_import1
-BuildRequires: openssh
-BuildRequires: distribution-logos
-BuildRequires: wallpaper-branding
+BuildRequires:  distribution-logos
+BuildRequires:  distribution-release
+BuildRequires:  libpcp-devel
+BuildRequires:  libpcp3
+BuildRequires:  libpcp_import1
+BuildRequires:  openssh
+BuildRequires:  pcp-devel
+BuildRequires:  wallpaper-branding
+# needed for /var/lib/pcp directory ownership
+BuildRequires:  pcp
 %else
-BuildRequires: pcp-libs-devel
-BuildRequires: openssh-clients
-BuildRequires: docbook-style-xsl
+BuildRequires:  docbook-style-xsl
+BuildRequires:  openssh-clients
+BuildRequires:  pcp-libs-devel
 %endif
-BuildRequires: krb5-server
-BuildRequires: gdb
+BuildRequires:  gdb
+BuildRequires:  krb5-server
 
 # For documentation
-BuildRequires: xmlto
+BuildRequires:  xmlto
+
+%if 0%{?with_selinux}
+BuildRequires:  selinux-policy
+BuildRequires:  selinux-policy-%{selinuxtype}
+BuildRequires:  selinux-policy-devel
+%endif
+
+# for rebuilding nodejs bits
+BuildRequires:  local-npm-registry
+BuildRequires:  npm
+BuildRequires:  sassc
 
 # This is the "cockpit" metapackage. It should only
 # Require, Suggest or Recommend other cockpit-xxx subpackages
 
-Requires: cockpit-bridge
-Requires: cockpit-ws
-Requires: cockpit-system
+Requires:       cockpit-bridge
+Requires:       cockpit-system
+Requires:       cockpit-ws
 
 # Optional components
-Recommends: (cockpit-storaged if udisks2)
-Recommends: cockpit-packagekit
-Suggests: cockpit-pcp
+Recommends:     (cockpit-storaged if udisks2)
+Recommends:     cockpit-packagekit
+Suggests:       cockpit-pcp
 
 %if 0%{?rhel} == 0
-Recommends: (cockpit-networkmanager if NetworkManager)
-Suggests: cockpit-selinux
+Recommends:     (cockpit-networkmanager if NetworkManager)
+Suggests:       cockpit-selinux
 %endif
 %if 0%{?rhel} && 0%{?centos} == 0
-Recommends: subscription-manager-cockpit
+Recommends:     subscription-manager-cockpit
 %endif
 
 %prep
 %setup -q -n cockpit-%{version}
+%autopatch -p1
+cp %SOURCE1 tools/cockpit.pam
+#
+local-npm-registry %{_sourcedir} install --also=dev --legacy-peer-deps
 
 %build
+find node_modules -name \*.node -print -delete
+touch node_modules/.stamp
+
 exec 2>&1
+PKG_NAME="Cockpit"
+echo %version > .tarball
+autoreconf -fvi -I tools
+#
 %configure \
     --disable-silent-rules \
     --with-cockpit-user=cockpit-ws \
     --with-cockpit-ws-instance-user=cockpit-wsinstance \
     --with-selinux-config-type=etc_t \
-    --with-appstream-data-packages='[ "appstream-data" ]' \
-    --with-nfs-client-package='"nfs-utils"' \
 %if 0%{?suse_version}
     --docdir=%_defaultdocdir/%{name} \
 %endif
     --with-pamdir='%{pamdir}' \
-    %{?vdo_on_demand:--with-vdo-package='"vdo"'}
+%if 0%{?build_basic} == 0
+    --disable-ssh \
+%endif
+
 make -j4 %{?extra_flags} all
 
+%if 0%{?with_selinux}
+    make -f /usr/share/selinux/devel/Makefile cockpit.pp
+    bzip2 -9 cockpit.pp
+%endif
+
 %check
-exec 2>&1
 # HACK: Fedora koji builders are very slow, unreliable, and inaccessible for debugging; https://github.com/cockpit-project/cockpit/issues/13909
 %if 0%{?fedora} >= 0
 %ifarch s390x
@@ -181,35 +223,39 @@ exec 2>&1
 %define testsuite_skip #
 %endif
 %endif
-%{?testsuite_skip} make -j4 check %{?testsuite_fail}
+%{?testsuite_skip} make -j4 check || { ls -l /dev/std* ; [ -e ./test-suite.log ] && cat ./test-suite.log ; false; } %{?testsuite_fail}
 
 %install
-%make_install
+# In obs we get  write error: stdout
+%make_install | tee make_install.log
 make install-tests DESTDIR=%{buildroot}
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
-# shipped in firewalld since 0.6, everywhere in Fedora/RHEL 8
-rm -f %{buildroot}/%{_prefix}/%{__lib}/firewalld/services/cockpit.xml
 install -D -p -m 644 AUTHORS COPYING README.md %{buildroot}%{_docdir}/cockpit/
+
+%if 0%{?with_selinux}
+    install -D -m 644 %{name}.pp.bz2 %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
+    install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_session_selinux.8cockpit
+    install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_ws_selinux.8cockpit
+    # create this directory in the build root so that %ghost sees the desired mode
+    install -d -m 700 %{buildroot}%{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
+%endif
+
+# only ship deprecated PatternFly API for stable releases
+%if 0%{?fedora} <= 33 || 0%{?rhel} <= 8
+    ln -s cockpit.css.gz %{buildroot}/%{_datadir}/cockpit/base1/patternfly.css.gz
+%endif
 
 # Build the package lists for resource packages
 echo '%dir %{_datadir}/cockpit/base1' > base.list
 echo '%dir %{_datadir}/cockpit/base1/fonts' >> base.list
-find %{buildroot}%{_datadir}/cockpit/base1 -type f >> base.list
+find %{buildroot}%{_datadir}/cockpit/base1 -type f -o -type l >> base.list
 echo '%{_sysconfdir}/cockpit/machines.d' >> base.list
 echo %{buildroot}%{_datadir}/polkit-1/actions/org.cockpit-project.cockpit-bridge.policy >> base.list
 echo '%dir %{_datadir}/cockpit/ssh' >> base.list
 find %{buildroot}%{_datadir}/cockpit/ssh -type f >> base.list
 echo '%{_libexecdir}/cockpit-ssh' >> base.list
-
-%if %{defined build_dashboard}
-echo '%dir %{_datadir}/cockpit/dashboard' >> dashboard.list
-find %{buildroot}%{_datadir}/cockpit/dashboard -type f >> dashboard.list
-%else
-rm -rf %{buildroot}/%{_datadir}/cockpit/dashboard
-touch dashboard.list
-%endif
 
 echo '%dir %{_datadir}/cockpit/pcp' >> pcp.list
 find %{buildroot}%{_datadir}/cockpit/pcp -type f >> pcp.list
@@ -225,6 +271,9 @@ find %{buildroot}%{_datadir}/cockpit/systemd -type f >> system.list
 
 echo '%dir %{_datadir}/cockpit/users' >> system.list
 find %{buildroot}%{_datadir}/cockpit/users -type f >> system.list
+
+echo '%dir %{_datadir}/cockpit/metrics' >> system.list
+find %{buildroot}%{_datadir}/cockpit/metrics -type f >> system.list
 
 echo '%dir %{_datadir}/cockpit/kdump' >> kdump.list
 find %{buildroot}%{_datadir}/cockpit/kdump -type f >> kdump.list
@@ -244,37 +293,29 @@ find %{buildroot}%{_datadir}/cockpit/packagekit -type f >> packagekit.list
 echo '%dir %{_datadir}/cockpit/apps' >> packagekit.list
 find %{buildroot}%{_datadir}/cockpit/apps -type f >> packagekit.list
 
-echo '%dir %{_datadir}/cockpit/machines' > machines.list
-find %{buildroot}%{_datadir}/cockpit/machines -type f >> machines.list
-
 echo '%dir %{_datadir}/cockpit/selinux' > selinux.list
 find %{buildroot}%{_datadir}/cockpit/selinux -type f >> selinux.list
 
 echo '%dir %{_datadir}/cockpit/playground' > tests.list
 find %{buildroot}%{_datadir}/cockpit/playground -type f >> tests.list
 
-%if 0%{?build_docker}
-echo '%dir %{_datadir}/cockpit/docker' > docker.list
-find %{buildroot}%{_datadir}/cockpit/docker -type f >> docker.list
-%else
-rm -rf %{buildroot}/%{_datadir}/cockpit/docker
-rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-docker.metainfo.xml
-touch docker.list
-%endif
+echo '%dir %{_datadir}/cockpit/static' > static.list
+echo '%dir %{_datadir}/cockpit/static/fonts' >> static.list
+find %{buildroot}%{_datadir}/cockpit/static -type f >> static.list
 
 # when not building basic packages, remove their files
 %if 0%{?build_basic} == 0
-for pkg in base1 branding motd kdump networkmanager selinux shell sosreport ssh static systemd tuned users; do
+for pkg in base1 branding motd kdump networkmanager selinux shell sosreport ssh static systemd tuned users metrics; do
     rm -r %{buildroot}/%{_datadir}/cockpit/$pkg
     rm -f %{buildroot}/%{_datadir}/metainfo/org.cockpit-project.cockpit-${pkg}.metainfo.xml
 done
 for data in doc locale man pixmaps polkit-1; do
     rm -r %{buildroot}/%{_datadir}/$data
 done
-for lib in systemd tmpfiles.d firewalld; do
+for lib in systemd tmpfiles.d; do
     rm -r %{buildroot}/%{_prefix}/%{__lib}/$lib
 done
-for libexec in cockpit-askpass cockpit-session cockpit-ws cockpit-tls cockpit-wsinstance-factory cockpit-desktop; do
+for libexec in cockpit-askpass cockpit-session cockpit-ws cockpit-tls cockpit-wsinstance-factory cockpit-desktop cockpit-certificate-helper cockpit-certificate-ensure; do
     rm %{buildroot}/%{_libexecdir}/$libexec
 done
 rm -r %{buildroot}/%{_libdir}/security %{buildroot}/%{_sysconfdir}/pam.d %{buildroot}/%{_sysconfdir}/motd.d %{buildroot}/%{_sysconfdir}/issue.d
@@ -285,24 +326,23 @@ rm -f %{buildroot}%{_datadir}/metainfo/cockpit.appdata.xml
 
 # when not building optional packages, remove their files
 %if 0%{?build_optional} == 0
-for pkg in apps dashboard docker machines packagekit pcp playground storaged; do
+for pkg in apps packagekit pcp playground storaged; do
     rm -rf %{buildroot}/%{_datadir}/cockpit/$pkg
 done
 # files from -tests
 rm -r %{buildroot}/%{_prefix}/%{__lib}/cockpit-test-assets
 # files from -pcp
 rm -r %{buildroot}/%{_libexecdir}/cockpit-pcp %{buildroot}/%{_localstatedir}/lib/pcp/
-# files from -machines
-rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-machines.metainfo.xml
 # files from -storaged
 rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-storaged.metainfo.xml
-# files from -docker
-rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-docker.metainfo.xml
 %endif
 
 sed -i "s|%{buildroot}||" *.list
 
 %if 0%{?suse_version}
+# setroubleshoot not yet in
+rm -r %{buildroot}%{_datadir}/cockpit/selinux
+rm %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml
 # remove brandings with stale symlinks. Means they don't match
 # the distro.
 pushd %{buildroot}/%{_datadir}/cockpit/branding
@@ -310,24 +350,16 @@ find -L * -type l -printf "%H\n" | sort -u | xargs rm -rv
 popd
 # need this in SUSE as post build checks dislike stale symlinks
 install -m 644 -D /dev/null %{buildroot}/run/cockpit/motd
+# remove files of not installable packages
+rm -r %{buildroot}%{_datadir}/cockpit/sosreport
+rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-sosreport.metainfo.xml
+rm -f %{buildroot}%{_datadir}/pixmaps/cockpit-sosreport.png
 %else
 %global _debugsource_packages 1
 %global _debuginfo_subpackages 0
 
 %define find_debug_info %{_rpmconfigdir}/find-debuginfo.sh %{?_missing_build_ids_terminate_build:--strict-build-id} %{?_include_minidebuginfo:-m} %{?_find_debuginfo_dwz_opts} %{?_find_debuginfo_opts} %{?_debugsource_packages:-S debugsourcefiles.list} "%{_builddir}/%{?buildsubdir}"
 
-# Redefine how debug info is built to slip in our extra debug files
-%define __debug_install_post   \
-   %{find_debug_info} \
-   cat debug.partial >> %{_builddir}/%{?buildsubdir}/debugfiles.list \
-%{nil}
-
-# Build the package lists for debug package, and move debug files to installed locations
-find %{buildroot}/usr/src/debug%{_datadir}/cockpit -type f -o -type l > debug.partial
-sed -i "s|%{buildroot}/usr/src/debug||" debug.partial
-sed -n 's/\.map\(\.gz\)\?$/\0/p' *.list >> debug.partial
-sed -i '/\.map\(\.gz\)\?$/d' *.list
-tar -C %{buildroot}/usr/src/debug -cf - . | tar -C %{buildroot} -xf -
 %endif
 # /suse_version
 rm -rf %{buildroot}/usr/src/debug
@@ -340,6 +372,9 @@ rm -f %{buildroot}%{_datadir}/metainfo/org.cockpit-project.cockpit-kdump.metainf
 rm -f %{buildroot}%{_datadir}/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml
 rm -f %{buildroot}%{_datadir}/pixmaps/cockpit-sosreport.png
 %endif
+
+mkdir -p %{buildroot}%{_datadir}/cockpit/devel
+cp -a pkg/lib %{buildroot}%{_datadir}/cockpit/devel
 
 %if 0%{?build_basic}
 %find_lang cockpit
@@ -366,15 +401,19 @@ troubleshooting, interactive command-line sessions, and more.
 %{_datadir}/pixmaps/cockpit.png
 %doc %{_mandir}/man1/cockpit.1.gz
 
-
 %package bridge
-Summary: Cockpit bridge server-side component
-Requires: glib-networking
-Provides: cockpit-ssh = %{version}-%{release}
-# cockpit-ssh moved from dashboard to bridge in 171
-Conflicts: cockpit-dashboard < 170.x
+Summary:        Cockpit bridge server-side component
+Requires:       glib-networking
+Provides:       cockpit-ssh = %{version}-%{release}
 # PR #10430 dropped workaround for ws' inability to understand x-host-key challenge
-Conflicts: cockpit-ws < 181.x
+Conflicts:      cockpit-ws < 181.x
+# 233 dropped jquery.js, pages started to bundle it (commit 049e8b8dce)
+Conflicts:      cockpit-dashboard < 233
+Conflicts:      cockpit-networkmanager < 233
+Conflicts:      cockpit-storaged < 233
+Conflicts:      cockpit-system < 233
+Conflicts:      cockpit-tests < 233
+Conflicts:      cockpit-docker < 233
 
 %description bridge
 The Cockpit bridge component installed server side and runs commands on the
@@ -386,8 +425,8 @@ system on behalf of the web based user interface.
 %{_libexecdir}/cockpit-askpass
 
 %package doc
-Summary: Cockpit deployment and developer guide
-BuildArch: noarch
+Summary:        Cockpit deployment and developer guide
+BuildArch:      noarch
 
 %description doc
 The Cockpit Deployment and Developer Guide shows sysadmins how to
@@ -401,44 +440,42 @@ embed or extend Cockpit.
 %{_docdir}/cockpit
 
 %package system
-Summary: Cockpit admin interface package for configuring and troubleshooting a system
-BuildArch: noarch
-Requires: cockpit-bridge >= %{version}-%{release}
+Summary:        Cockpit admin interface package for configuring and troubleshooting a system
+BuildArch:      noarch
+Requires:       cockpit-bridge >= %{version}-%{release}
 %if !0%{?suse_version}
-Requires: shadow-utils
+Requires:       shadow-utils
 %endif
-Requires: grep
-Requires: /usr/bin/pwscore
-Requires: /usr/bin/date
-Provides: cockpit-shell = %{version}-%{release}
-Provides: cockpit-systemd = %{version}-%{release}
-Provides: cockpit-tuned = %{version}-%{release}
-Provides: cockpit-users = %{version}-%{release}
+Requires:       /usr/bin/date
+Requires:       /usr/bin/pwscore
+Requires:       grep
+Provides:       cockpit-shell = %{version}-%{release}
+Provides:       cockpit-systemd = %{version}-%{release}
+Provides:       cockpit-tuned = %{version}-%{release}
+Provides:       cockpit-users = %{version}-%{release}
+Obsoletes:      cockpit-dashboard < %{version}-%{release}
 %if 0%{?rhel}
-Provides: cockpit-networkmanager = %{version}-%{release}
-Obsoletes: cockpit-networkmanager
-Requires: NetworkManager >= 1.6
-Provides: cockpit-kdump = %{version}-%{release}
-Requires: kexec-tools
-Recommends: polkit
-Recommends: PackageKit
-Recommends: NetworkManager-team
-Recommends: setroubleshoot-server >= 3.3.3
-Provides: cockpit-selinux = %{version}-%{release}
-Provides: cockpit-sosreport = %{version}-%{release}
-Requires: sos
+Provides:       cockpit-networkmanager = %{version}-%{release}
+Requires:       NetworkManager >= 1.6
+Provides:       cockpit-kdump = %{version}-%{release}
+Requires:       kexec-tools
+Recommends:     (sudo or polkit)
+Recommends:     PackageKit
+Recommends:     NetworkManager-team
+Recommends:     setroubleshoot-server >= 3.3.3
+Provides:       cockpit-selinux = %{version}-%{release}
+Provides:       cockpit-sosreport = %{version}-%{release}
+Requires:       sos
 %endif
 %if 0%{?fedora} >= 29
 # 0.7.0 (actually) supports task cancellation.
 # 0.7.1 fixes tasks never announcing completion.
-Recommends: (reportd >= 0.7.1 if abrt)
+Recommends:     (reportd >= 0.7.1 if abrt)
 %endif
 # NPM modules which are also available as packages
-Provides: bundled(js-jquery) = %{npm-version:jquery}
-Provides: bundled(js-moment) = %{npm-version:moment}
-Provides: bundled(nodejs-flot) = %{npm-version:jquery-flot}
-Provides: bundled(xstatic-bootstrap-datepicker-common) = %{npm-version:bootstrap-datepicker}
-Provides: bundled(xstatic-patternfly-common) = %{npm-version:patternfly}
+Provides:       bundled(js-jquery) = 3.5.1
+Provides:       bundled(xstatic-bootstrap-datepicker-common) = 1.9.0
+Provides:       bundled(xstatic-patternfly-common) = 3.59.5
 
 %description system
 This package contains the Cockpit shell and system configuration interfaces.
@@ -447,21 +484,19 @@ This package contains the Cockpit shell and system configuration interfaces.
 %dir %{_datadir}/cockpit/shell/images
 
 %package ws
-Summary: Cockpit Web Service
-Requires: glib-networking
-Requires: openssl
-Requires: glib2 >= 2.50.0
-Conflicts: firewalld < 0.6.0-1
-Recommends: sscg >= 2.3
-Recommends: system-logos
-Suggests: sssd-dbus
-%if !0%{?suse_version}
-Requires: systemd >= 235
-Requires(post): systemd
-Requires(preun): systemd
-Requires(postun): systemd
-%else
-Requires: group(wheel)
+Summary:        Cockpit Web Service
+Requires:       glib-networking
+Requires:       glib2 >= 2.50.0
+Requires:       openssl
+%if 0%{?with_selinux}
+Requires:       (selinux-policy >= %{selinux_policy_version} if selinux-policy-%{selinuxtype})
+Requires(post): (policycoreutils if selinux-policy-%{selinuxtype})
+%endif
+Conflicts:      firewalld < 0.6.0-1
+Recommends:     sscg >= 2.3
+Recommends:     system-logos
+Suggests:       sssd-dbus
+%if 0%{?suse_version}
 Requires(pre): permissions
 %endif
 
@@ -471,21 +506,23 @@ The Cockpit Web Service listens on the network, and authenticates users.
 If sssd-dbus is installed, you can enable client certificate/smart card
 authentication via sssd/FreeIPA.
 
-%files ws -f cockpit.lang
+%files ws -f cockpit.lang -f static.list
 %doc %{_mandir}/man1/cockpit-desktop.1.gz
 %doc %{_mandir}/man5/cockpit.conf.5.gz
 %doc %{_mandir}/man8/cockpit-ws.8.gz
 %doc %{_mandir}/man8/cockpit-tls.8.gz
 %doc %{_mandir}/man8/remotectl.8.gz
-%doc %{_mandir}/man8/pam_cockpit_cert.8.gz
 %doc %{_mandir}/man8/pam_ssh_add.8.gz
 %dir %{_sysconfdir}/cockpit
 %config(noreplace) %{_sysconfdir}/cockpit/ws-certs.d
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
-%config %{_sysconfdir}/issue.d/cockpit.issue
-%config %{_sysconfdir}/motd.d/cockpit
-%ghost /run/cockpit/motd
+# dir is not owned by pam in openSUSE
+%dir %{_sysconfdir}/motd.d
+# created in %post, so that users can rm the files
+%ghost %{_sysconfdir}/issue.d/cockpit.issue
+%ghost %{_sysconfdir}/motd.d/cockpit
 %ghost %dir /run/cockpit
+%ghost /run/cockpit/motd
 %dir %{_datadir}/cockpit/motd
 %{_datadir}/cockpit/motd/update-motd
 %{_datadir}/cockpit/motd/inactive.motd
@@ -509,10 +546,17 @@ authentication via sssd/FreeIPA.
 %{_libexecdir}/cockpit-wsinstance-factory
 %{_libexecdir}/cockpit-tls
 %{_libexecdir}/cockpit-desktop
-%attr(4750, root, cockpit-wsinstance) %{_libexecdir}/cockpit-session
-%attr(775, -, wheel) %{_localstatedir}/lib/cockpit
-%{_datadir}/cockpit/static
+%{_libexecdir}/cockpit-certificate-ensure
+%{_libexecdir}/cockpit-certificate-helper
+%{?suse_version:%verify(not mode) }%attr(4750, root, cockpit-wsinstance) %{_libexecdir}/cockpit-session
 %{_datadir}/cockpit/branding
+
+%if 0%{?with_selinux}
+    %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
+    %{_mandir}/man8/%{name}_session_selinux.8cockpit.*
+    %{_mandir}/man8/%{name}_ws_selinux.8cockpit.*
+    %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
+%endif
 
 %pre ws
 getent group cockpit-ws >/dev/null || groupadd -r cockpit-ws
@@ -520,21 +564,53 @@ getent passwd cockpit-ws >/dev/null || useradd -r -g cockpit-ws -d /nonexisting 
 getent group cockpit-wsinstance >/dev/null || groupadd -r cockpit-wsinstance
 getent passwd cockpit-wsinstance >/dev/null || useradd -r -g cockpit-wsinstance -d /nonexisting -s /sbin/nologin -c "User for cockpit-ws instances" cockpit-wsinstance
 
+%if 0%{?with_selinux}
+if %{_sbindir}/selinuxenabled 2>/dev/null; then
+    %selinux_relabel_pre -s %{selinuxtype}
+fi
+%endif
+
 %post ws
+%if 0%{?with_selinux}
+if %{_sbindir}/selinuxenabled 2>/dev/null; then
+    %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
+    %selinux_relabel_post -s %{selinuxtype}
+fi
+%endif
+
+# set up dynamic motd/issue symlinks on first-time install; don't bring them back on upgrades if admin removed them
+if [ "$1" = 1 ]; then
+    mkdir -p /etc/motd.d /etc/issue.d
+    ln -s /run/cockpit/motd /etc/motd.d/cockpit
+    ln -s /run/cockpit/motd /etc/issue.d/cockpit.issue
+fi
 %if 0%{?suse_version}
 %set_permissions %{_libexecdir}/cockpit-session
-%tmpfiles_create cockpit-tempfiles.conf
 %endif
-%systemd_post cockpit.socket
+%tmpfiles_create cockpit-tempfiles.conf
+%systemd_post cockpit.socket cockpit.service
 # firewalld only partially picks up changes to its services files without this
 test -f %{_bindir}/firewall-cmd && firewall-cmd --reload --quiet || true
 
+# check for deprecated PAM config
+if grep --color=auto pam_cockpit_cert %{_sysconfdir}/pam.d/cockpit; then
+    echo '**** WARNING:'
+    echo '**** WARNING: pam_cockpit_cert is a no-op and will be removed in a'
+    echo '**** WARNING: future release; remove it from your /etc/pam.d/cockpit.'
+    echo '**** WARNING:'
+fi
+
 %preun ws
-%systemd_preun cockpit.socket
+%systemd_preun cockpit.socket cockpit.service
 
 %postun ws
-%systemd_postun_with_restart cockpit.socket
-%systemd_postun_with_restart cockpit.service
+%if 0%{?with_selinux}
+if %{_sbindir}/selinuxenabled 2>/dev/null; then
+    %selinux_modules_uninstall -s %{selinuxtype} %{name}
+    %selinux_relabel_post -s %{selinuxtype}
+fi
+%endif
+%systemd_postun_with_restart cockpit.socket cockpit.service
 
 %if 0%{?suse_version}
 %verifyscript ws
@@ -547,11 +623,11 @@ test -f %{_bindir}/firewall-cmd && firewall-cmd --reload --quiet || true
 %if 0%{?rhel} == 0
 
 %package kdump
-Summary: Cockpit user interface for kernel crash dumping
-Requires: cockpit-bridge >= %{required_base}
-Requires: cockpit-shell >= %{required_base}
-Requires: kexec-tools
-BuildArch: noarch
+Summary:        Cockpit user interface for kernel crash dumping
+Requires:       cockpit-bridge >= 122
+Requires:       cockpit-shell >= 122
+Requires:       kexec-tools
+BuildArch:      noarch
 
 %description kdump
 The Cockpit component for configuring kernel crash dumping.
@@ -559,12 +635,13 @@ The Cockpit component for configuring kernel crash dumping.
 %files kdump -f kdump.list
 %{_datadir}/metainfo/org.cockpit-project.cockpit-kdump.metainfo.xml
 
+%if !0%{?suse_version}
 %package sosreport
-Summary: Cockpit user interface for diagnostic reports
-Requires: cockpit-bridge >= %{required_base}
-Requires: cockpit-shell >= %{required_base}
-Requires: sos
-BuildArch: noarch
+Summary:        Cockpit user interface for diagnostic reports
+Requires:       cockpit-bridge >= 122
+Requires:       cockpit-shell >= 122
+Requires:       sos
+BuildArch:      noarch
 
 %description sosreport
 The Cockpit component for creating diagnostic reports with the
@@ -573,15 +650,16 @@ sosreport tool.
 %files sosreport -f sosreport.list
 %{_datadir}/metainfo/org.cockpit-project.cockpit-sosreport.metainfo.xml
 %{_datadir}/pixmaps/cockpit-sosreport.png
+%endif
 
 %package networkmanager
-Summary: Cockpit user interface for networking, using NetworkManager
-Requires: cockpit-bridge >= %{required_base}
-Requires: cockpit-shell >= %{required_base}
-Requires: NetworkManager >= 1.6
+Summary:        Cockpit user interface for networking, using NetworkManager
+Requires:       NetworkManager >= 1.6
+Requires:       cockpit-bridge >= 186
+Requires:       cockpit-shell >= 186
 # Optional components
-Recommends: NetworkManager-team
-BuildArch: noarch
+Recommends:     NetworkManager-team
+BuildArch:      noarch
 
 %description networkmanager
 The Cockpit component for managing networking.  This package uses NetworkManager.
@@ -590,14 +668,14 @@ The Cockpit component for managing networking.  This package uses NetworkManager
 
 %endif
 
-%if 0%{?rhel} == 0
+%if 0%{?rhel} == 0 && !0%{?suse_version}
 
 %package selinux
-Summary: Cockpit SELinux package
-Requires: cockpit-bridge >= %{required_base}
-Requires: cockpit-shell >= %{required_base}
-Requires: setroubleshoot-server >= 3.3.3
-BuildArch: noarch
+Summary:        Cockpit SELinux package
+Requires:       cockpit-bridge >= 122
+Requires:       cockpit-shell >= 122
+Requires:       setroubleshoot-server >= 3.3.3
+BuildArch:      noarch
 
 %description selinux
 This package contains the Cockpit user interface integration with the
@@ -624,20 +702,20 @@ Dummy package from building optional packages only; never install or publish me.
 %if 0%{?build_optional}
 
 %package -n cockpit-storaged
-Summary: Cockpit user interface for storage, using udisks
-Requires: cockpit-shell >= %{required_base}
-Requires: udisks2 >= 2.6
-Recommends: udisks2-lvm2 >= 2.6
-Recommends: udisks2-iscsi >= 2.6
-Recommends: device-mapper-multipath
-Recommends: clevis-luks
-Requires: %{__python3}
+Summary:        Cockpit user interface for storage, using udisks
+Requires:       cockpit-shell >= 186
+Requires:       udisks2 >= 2.6
+Recommends:     udisks2-lvm2 >= 2.6
+Recommends:     udisks2-iscsi >= 2.6
+Recommends:     device-mapper-multipath
+Recommends:     clevis-luks
+Requires:       %{__python3}
 %if 0%{?suse_version}
-Requires: python3-dbus-python
+Requires:       python3-dbus-python
 %else
-Requires: python3-dbus
+Requires:       python3-dbus
 %endif
-BuildArch: noarch
+BuildArch:      noarch
 
 %description -n cockpit-storaged
 The Cockpit component for managing storage.  This package uses udisks.
@@ -647,11 +725,11 @@ The Cockpit component for managing storage.  This package uses udisks.
 %{_datadir}/metainfo/org.cockpit-project.cockpit-storaged.metainfo.xml
 
 %package -n cockpit-tests
-Summary: Tests for Cockpit
-Requires: cockpit-bridge >= 138
-Requires: cockpit-system >= 138
-Requires: openssh-clients
-Provides: cockpit-test-assets = %{version}-%{release}
+Summary:        Tests for Cockpit
+Requires:       cockpit-bridge >= 138
+Requires:       cockpit-system >= 138
+Requires:       openssh-clients
+Provides:       cockpit-test-assets = %{version}-%{release}
 
 %description -n cockpit-tests
 This package contains tests and files used while testing Cockpit.
@@ -660,35 +738,19 @@ These files are not required for running Cockpit.
 %files -n cockpit-tests -f tests.list
 %{_prefix}/%{__lib}/cockpit-test-assets
 
-%package -n cockpit-machines
-BuildArch: noarch
-Summary: Cockpit user interface for virtual machines
-Requires: cockpit-bridge >= %{required_base}
-Requires: cockpit-system >= %{required_base}
-%if 0%{?suse_version}
-Requires: libvirt-daemon-qemu
-%else
-Requires: libvirt-daemon-kvm
-%endif
-Requires: libvirt-client
-Requires: libvirt-dbus >= 1.2.0
-# Optional components
-Recommends: virt-install
-Recommends: libosinfo
-Recommends: python3-gobject-base
+%package devel
+Summary:        Development files for for Cockpit
 
-%description -n cockpit-machines
-The Cockpit components for managing virtual machines.
+%description devel
+This package contains files used to develop cockpit modules
 
-If "virt-install" is installed, you can also create new virtual machines.
-
-%files -n cockpit-machines -f machines.list
-%{_datadir}/metainfo/org.cockpit-project.cockpit-machines.metainfo.xml
+%files devel
+%{_datadir}/cockpit/devel
 
 %package -n cockpit-pcp
-Summary: Cockpit PCP integration
-Requires: cockpit-bridge >= %{required_base}
-Requires(post): pcp
+Summary:        Cockpit PCP integration
+Requires:       cockpit-bridge >= 238.1.1
+Requires:       pcp
 
 %description -n cockpit-pcp
 Cockpit support for reading PCP metrics and loading PCP archives.
@@ -698,46 +760,16 @@ Cockpit support for reading PCP metrics and loading PCP archives.
 %{_localstatedir}/lib/pcp/config/pmlogconf/tools/cockpit
 
 %post -n cockpit-pcp
-# HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1185764
-# We can't use "systemctl reload-or-try-restart" since systemctl might
-# be out of sync with reality.
-/usr/share/pcp/lib/pmlogger condrestart
-
-%if %{defined build_dashboard}
-%package -n cockpit-dashboard
-Summary: Cockpit remote server dashboard
-BuildArch: noarch
-Requires: cockpit-ssh >= 135
-Conflicts: cockpit-ws < 135
-
-%description -n cockpit-dashboard
-Cockpit page for showing performance graphs for up to 20 remote servers.
-
-%files -n cockpit-dashboard -f dashboard.list
-
-%endif
-
-%if 0%{?build_docker}
-%package -n cockpit-docker
-Summary: Cockpit user interface for Docker containers
-Requires: cockpit-bridge >= %{required_base}
-Requires: cockpit-shell >= %{required_base}
-Requires: (docker or moby-engine or docker-ce)
-Requires: %{__python3}
-
-%description -n cockpit-docker
-The Cockpit components for interacting with Docker and user interface.
-This package is not yet complete.
-
-%files -n cockpit-docker -f docker.list
-%{_datadir}/metainfo/org.cockpit-project.cockpit-docker.metainfo.xml
-%endif
+systemctl reload-or-try-restart pmlogger
 
 %package -n cockpit-packagekit
-Summary: Cockpit user interface for packages
-BuildArch: noarch
-Requires: cockpit-bridge >= %{required_base}
-Requires: PackageKit
+Summary:        Cockpit user interface for packages
+BuildArch:      noarch
+Requires:       PackageKit
+Requires:       cockpit-bridge >= 186
+Recommends:     python3-tracer
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1800468
+Requires:       polkit
 
 %description -n cockpit-packagekit
 The Cockpit components for installing OS updates and Cockpit add-ons,
@@ -749,4 +781,5 @@ via PackageKit.
 %endif
 
 # The changelog is automatically generated and merged
+
 %changelog


### PR DESCRIPTION
- Fix build error for Leap
  - Insert SetBadness for setuid in Leap 15.4
  - Only require selinux for Tumbleweed and not for Leap.
  - Set _pamdir to /%{_lib}/security.